### PR TITLE
FDIS-9: Upgrade folio-di-support to Vert.x 4.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </licenses>
 
   <properties>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <vertx.version>4.1.4</vertx.version>
     <spring.version>5.2.8.RELEASE</spring.version>
     <junit.version>4.13.1</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
RMB >= 33.1.1 requires Vert.x >= 4.1.3 because
Context.get has changed its signature from get(String) to get(Object).